### PR TITLE
feat: Add Battery Butler privacy policy

### DIFF
--- a/public/battery-butler-privacy-policy.html
+++ b/public/battery-butler-privacy-policy.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<!--
+  ISC License
+  Copyright (c) 2024, Christopher Cartland
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Privacy Policy for Battery Butler app by Christopher Cartland"
+    />
+    <meta name="theme-color" content="#263551" />
+    <title>Battery Butler Privacy Policy</title>
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link
+      rel="canonical"
+      href="https://chriscart.land/battery-butler-privacy-policy"
+    />
+  </head>
+
+  <body>
+    <main id="main-content">
+      <article>
+        <header>
+          <h1>Battery Butler Privacy Policy</h1>
+          <p>
+            <time datetime="2026-02-18"
+              >Effective Date: February 18th, 2026</time
+            >
+          </p>
+        </header>
+
+        <section>
+          <p>
+            <strong>Important Note:</strong> This app is designed for private
+            use by the author (Christopher Cartland) and individuals
+            specifically granted access. If you have come across this app
+            accidentally, please delete it.
+          </p>
+
+          <p>
+            You can find the app on the Google Play Store here:
+            <a
+              href="https://play.google.com/store/apps/details?id=com.chriscartland.batterybutler"
+              >Battery Butler on Google Play</a
+            >. This link should only be accessed by those who have been given
+            express permission by the author.
+          </p>
+        </section>
+
+        <section>
+          <h2>Information We Collect</h2>
+          <p>We may collect the following information:</p>
+          <ul>
+            <li>
+              Usage data: How often the app is opened, the version of the app,
+              how often data is delivered, and other metrics to ensure the app
+              is working.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>How We Use Your Information</h2>
+          <p>We use your information to:</p>
+          <ul>
+            <li>
+              Monitor and improve app performance: Analyze usage data to
+              identify bugs, optimize features, and enhance user experience.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Data Sharing</h2>
+          <p>We do not share your information with any third parties.</p>
+        </section>
+
+        <section>
+          <h2>Your Choices</h2>
+          <p>You have the following choices regarding your data:</p>
+          <ul>
+            <li>
+              Delete your app: This will remove all stored data from your
+              device.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Security</h2>
+          <p>
+            We take reasonable measures to protect your information. Data is
+            stored using Google and Amazon infrastructure with proper security
+            practices in place. However, no method of transmission over the
+            internet is completely secure.
+          </p>
+        </section>
+
+        <section>
+          <h2>Children's Privacy</h2>
+          <p>This app is not intended for children.</p>
+        </section>
+
+        <section>
+          <h2>Changes to this Policy</h2>
+          <p>
+            We may update this policy from time to time. We will notify you of
+            any changes by posting the new policy on this page.
+          </p>
+        </section>
+
+        <footer>
+          <h2>Contact Us</h2>
+          <p>
+            If you have any questions, please contact us at
+            <a href="mailto:chris@chriscart.land">chris@chriscart.land</a>.
+          </p>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/public/battery-butler-privacy-policy.html
+++ b/public/battery-butler-privacy-policy.html
@@ -80,14 +80,45 @@
         </section>
 
         <section>
-          <h2>Your Choices</h2>
-          <p>You have the following choices regarding your data:</p>
+          <h2>Account and Data Deletion</h2>
+          <p>
+            If you would like to request deletion of your Battery Butler account
+            and associated data, follow these steps:
+          </p>
+          <ol>
+            <li>
+              Send an email to
+              <a href="mailto:chris@chriscart.land">chris@chriscart.land</a>
+              with the subject line "Battery Butler Account Deletion Request".
+            </li>
+            <li>
+              Include the email address associated with your Battery Butler
+              account.
+            </li>
+            <li>
+              You will receive a confirmation email once your request has been
+              processed.
+            </li>
+          </ol>
+
+          <h3>Data that will be deleted</h3>
+          <ul>
+            <li>Your account information</li>
+            <li>Usage data associated with your account</li>
+          </ul>
+
+          <h3>Data that may be retained</h3>
           <ul>
             <li>
-              Delete your app: This will remove all stored data from your
-              device.
+              Aggregated, anonymized analytics data that cannot be linked back
+              to your account.
             </li>
           </ul>
+          <p>
+            Account deletion requests will be processed within 30 days. You may
+            also uninstall the app at any time to remove all locally stored data
+            from your device.
+          </p>
         </section>
 
         <section>


### PR DESCRIPTION
## Summary
- Add privacy policy page for Battery Butler app based on the existing garage privacy policy
- References Google and Amazon infrastructure in the security section
- Includes Play Store link and current effective date

## Test plan
- [ ] Verify the page renders correctly in the Firebase preview deploy
- [ ] Check that the canonical URL resolves after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)