### PR TITLE
fix: Prevent hero title overlap on narrow screens

### DIFF
--- a/site/.vitepress/theme/components/HeroSection.vue
+++ b/site/.vitepress/theme/components/HeroSection.vue
@@ -144,6 +144,7 @@ import { withBase } from 'vitepress'
   margin-top: 8px;
   margin-bottom: 8px;
   font-size: 3em;
+  line-height: 1.2;
   border: none;
 }
 
@@ -267,6 +268,11 @@ import { withBase } from 'vitepress'
 
   .hero-text {
     width: 100%;
+    min-height: 0;
+  }
+
+  .hero-text h1 {
+    font-size: 2.2em;
   }
 
   .hero-img {


### PR DESCRIPTION
## Problem

On the new VitePress site (staging `/v2/`), the hero title **"Software Engineer and Tech Maker"** overlaps itself when it wraps to multiple lines on narrow screens. The `<h1>` used `font-size: 3em` with no explicit `line-height`, so the default tight line-height caused wrapped lines to collide.

## Fix

- `.hero-text h1`: add `line-height: 1.2`.
- Under `max-width: 600px`: reduce the title to `2.2em` and drop the fixed `min-height` so it wraps cleanly.

## Verification

Built and rendered headlessly at 360px and 414px: computed `line-height` is now `42.24px` for a `35.2px` font, and the title lays out on two non-overlapping lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)