### PR TITLE
fix: Align header with content; remove redundant logo title text

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -33,8 +33,13 @@ export default defineConfig({
   ],
 
   themeConfig: {
-    logo: '/i/ChristopherCartlandLogo.jpg',
-    siteTitle: 'Christopher Cartland',
+    // Logo carries the name via alt text for screen readers; the visible
+    // text label is redundant for sighted users who can see the logo.
+    logo: {
+      src: '/i/ChristopherCartlandLogo.jpg',
+      alt: 'Christopher Cartland',
+    },
+    siteTitle: false,
 
     nav: [
       { text: 'About', link: '/' },

--- a/site/.vitepress/theme/style.css
+++ b/site/.vitepress/theme/style.css
@@ -22,6 +22,11 @@
   --vp-c-default-2: rgba(255, 255, 255, 0.2);
   --vp-c-default-3: rgba(255, 255, 255, 0.1);
   --vp-c-default-soft: rgba(255, 255, 255, 0.05);
+
+  /* Shared content column. The nav bar's inner container is
+     calc(--vp-layout-max-width - 64px); constraining the page content to the
+     same box (below) keeps the header, content, and footer aligned. */
+  --vp-layout-max-width: 1024px;
 }
 
 .dark {
@@ -42,6 +47,24 @@
 
 .VPDoc {
   padding: 0 !important;
+}
+
+/* Constrain page content to the same centered column as the nav bar so the
+   header, content, and footer share consistent margins and alignment. */
+.VPPage {
+  max-width: var(--vp-layout-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 32px;
+  padding-right: 32px;
+  box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .VPPage {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 /* Nav logo styling */


### PR DESCRIPTION
Addresses header/content consistency feedback on the VitePress site.

## 1. Header ↔ content alignment
The nav bar rendered in a centered, capped column (`--vp-layout-max-width − 64px`) while page content (`layout: page`) ran full-bleed edge-to-edge — so the logo and nav links didn't align with the hero/content below them, and margins looked inconsistent.

Constrained the page content (`.VPPage`) to the **same centered column** as the nav, with matching gutters (32px desktop / 24px mobile). Set `--vp-layout-max-width: 1024px` (≈960px content column) so the header, content, grid, and footer all share one aligned column.

Verified the logo, hero, and intro share an identical left edge at 375px (24), 1280px (160), and 1600px (320), with no horizontal overflow and the 3-col projects grid intact.

## 2. Redundant logo title
The logo image already shows "Christopher Cartland", but `siteTitle` repeated it as a text label beside the logo. Set `siteTitle: false` to remove the duplicate, and moved the name into the logo's `alt` text so screen-reader users still get it (`logo: { src, alt }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)