### PR TITLE
fix: Remove light/dark toggle (site is dark-only)

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -8,7 +8,10 @@ export default defineConfig({
   base: '/v2/',
   cleanUrls: true,
   deadLinks: 'fail',
-  appearance: 'dark',
+  // Lock dark mode and hide the light/dark toggle: the site has no light
+  // theme (the :root and .dark color sets are identical), so the toggle is a
+  // no-op. 'force-dark' keeps dark mode and removes the switch from the nav.
+  appearance: 'force-dark',
 
   head: [
     ['link', { rel: 'icon', href: '/v2/favicon.ico', type: 'image/x-icon' }],


### PR DESCRIPTION
The site has no light theme — the `:root` and `.dark` color sets in `style.css` are identical, so the appearance toggle did nothing visible.

Switched `appearance: 'dark'` → `appearance: 'force-dark'`, which keeps dark mode and removes the toggle from the nav.

**Verified:** 0 `.VPSwitchAppearance` toggles in the nav, `html` stays `.dark`, body background remains `#130830`.

Follow-up (not in this PR): the now-unused light-mode `:root` color duplication in `style.css` could be collapsed into a single set for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)