### PR TITLE
improve: Clean up Projects layout; remove anchor-link TOC

### DIFF
--- a/site/.vitepress/theme/components/ProjectCard.vue
+++ b/site/.vitepress/theme/components/ProjectCard.vue
@@ -37,10 +37,15 @@ const props = defineProps<{
 .card {
   width: 100%;
   box-sizing: border-box;
+  display: flex;
   flex-direction: column;
-  margin-bottom: 32px;
   transition: background-color 0.3s ease;
   padding: 16px;
+  border-radius: 24px;
+}
+
+.card:hover {
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
 .card:target {

--- a/site/.vitepress/theme/components/ProjectGrid.vue
+++ b/site/.vitepress/theme/components/ProjectGrid.vue
@@ -15,16 +15,6 @@ import { projects } from '../data/projects'
       </p>
     </div>
 
-    <nav class="toc-container" aria-label="Table of contents">
-      <a
-        v-for="project in projects"
-        :key="project.id"
-        :href="`#${project.id}`"
-        class="toc"
-        >{{ project.title }}</a
-      >
-    </nav>
-
     <div class="project-grid">
       <ProjectCard
         v-for="project in projects"
@@ -48,31 +38,17 @@ import { projects } from '../data/projects'
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   justify-content: center;
-  gap: 0;
+  gap: 24px;
 }
 
 .section-header {
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
-.toc-container {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.toc {
-  padding-left: 16px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-  break-inside: avoid;
-  text-decoration: none;
-  color: var(--vp-c-text-2);
-}
-
-.toc:hover {
-  text-decoration: underline;
+@media (max-width: 900px) {
+  .project-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
Addresses feedback that the Projects page's list of anchor links was hard to read.

## Changes
- **Removed the table-of-contents nav** (a flat list of 19 anchor links). The cards are the index now.
- **Anchors preserved** — each card keeps its `id`, so `/projects#<id>` deep links still scroll to and highlight the project (`:target`). Verified `#google-tv` and `#portfolio`.
- **Grid:** `gap: 0 → 24px`, plus a 2-col breakpoint at 900px (3-col desktop / 2-col tablet / 1-col mobile).
- **Cards:** `.card` is now a real flex column (it had `flex-direction` without `display: flex`), so `margin-top: auto` on the link aligns CTA buttons across each row; added rounded corners + subtle hover background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)